### PR TITLE
Restructure PHP analysis staged targets to action/staged pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.2.11] - 2026-01-08
+
+### Changed
+- **PHP analysis staged targets renamed** for consistent `action/staged` pattern:
+  - `php/phpcs/staged` → `php/phpcs/check/staged`
+  - `php/phpstan/staged` → `php/phpstan/analyse/staged`
+  - `php/psalm/staged` → `php/psalm/analyse/staged`
+
+### Added
+- **`php/phpcs/fix/staged`**: Run PHP Code Beautifier on staged PHP files only
+
 ## [2.2.10] - 2026-01-06
 
 ### Fixed

--- a/modules/php/phpcs/phpcs.mk
+++ b/modules/php/phpcs/phpcs.mk
@@ -47,8 +47,11 @@ php/phpcs/fix: ## Run PHP Code Beautifier to auto-fix (phpcs_files= for paths, p
 	$(eval $@_cmd := $(phpcbf_bin) $(call phpcs_build_args))
 	$(call php_invoke,$($@_cmd))
 
-php/phpcs/staged: ## Run PHP CodeSniffer on staged PHP files only
+php/phpcs/check/staged: ## Run PHP CodeSniffer on staged PHP files only
 	$(call php_run_on_staged,$(phpcs_bin) -s)
+
+php/phpcs/fix/staged: ## Run PHP Code Beautifier on staged PHP files only
+	$(call php_run_on_staged,$(phpcbf_bin))
 
 endif # __MB_TEST_DISCOVERY__
 

--- a/modules/php/phpstan/phpstan.mk
+++ b/modules/php/phpstan/phpstan.mk
@@ -41,7 +41,7 @@ php/phpstan/analyse: ## Run PHPStan analysis (phpstan_files= for paths, phpstan_
 		$(call mb_printf_info,Results saved to $(phpstan_output_file))\
 	)
 
-php/phpstan/staged: ## Run PHPStan on staged PHP files only
+php/phpstan/analyse/staged: ## Run PHPStan on staged PHP files only
 	$(call php_run_on_staged,$(phpstan_bin) analyse)
 
 endif # __MB_TEST_DISCOVERY__

--- a/modules/php/psalm/psalm.mk
+++ b/modules/php/psalm/psalm.mk
@@ -40,7 +40,7 @@ php/psalm/analyse: ## Run Psalm analysis (psalm_files= for paths, psalm_args= fo
 		$(call mb_printf_info,Results saved to $(psalm_output_file))\
 	)
 
-php/psalm/staged: ## Run Psalm on staged PHP files only
+php/psalm/analyse/staged: ## Run Psalm on staged PHP files only
 	$(call php_run_on_staged,$(psalm_bin))
 
 endif # __MB_TEST_DISCOVERY__


### PR DESCRIPTION
## Summary
- Rename `php/phpcs/staged` → `php/phpcs/check/staged`
- Add new `php/phpcs/fix/staged` target
- Rename `php/phpstan/staged` → `php/phpstan/analyse/staged`
- Rename `php/psalm/staged` → `php/psalm/analyse/staged`

## Trello
https://trello.com/c/cZcsFQ3G

## Test plan
- [x] Module tests pass (phpcs, phpstan, psalm)
- [x] Core tests pass (262/263 - 1 unrelated localstack failure)
- [x] Module files parse correctly